### PR TITLE
Translate "Add delete/1, mocked/0, and mocked_process/1"

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,47 @@
+%{
+  configs: [
+    %{
+      name: "default",
+      strict: true,
+      # These are not in the default list
+      checks: [
+        {Credo.Check.Consistency.ExceptionNames, []},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+        {Credo.Check.Consistency.UnusedVariableNames, []},
+        {Credo.Check.Readability.BlockPipe, []},
+        {Credo.Check.Readability.ImplTrue, []},
+        {Credo.Check.Readability.MultiAlias, []},
+        {Credo.Check.Readability.NestedFunctionCalls, []},
+        {Credo.Check.Readability.OneArityFunctionInPipe, []},
+        {Credo.Check.Readability.OnePipePerLine, []},
+        {Credo.Check.Readability.SeparateAliasRequire, []},
+        {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+        {Credo.Check.Readability.SinglePipe, []},
+        {Credo.Check.Readability.Specs, []},
+        {Credo.Check.Readability.StrictModuleLayout, []},
+        {Credo.Check.Readability.WithCustomTaggedTuple, []},
+        {Credo.Check.Refactor.ABCSize, []},
+        {Credo.Check.Refactor.AppendSingleItem, []},
+        {Credo.Check.Refactor.Apply, []},
+        {Credo.Check.Refactor.CaseTrivialMatches, []},
+        {Credo.Check.Refactor.DoubleBooleanNegation, []},
+        {Credo.Check.Refactor.FilterReject, []},
+        {Credo.Check.Refactor.IoPuts, []},
+        {Credo.Check.Refactor.MapMap, []},
+        {Credo.Check.Refactor.ModuleDependencies, []},
+        {Credo.Check.Refactor.NegatedIsNil, []},
+        {Credo.Check.Refactor.PassAsyncInTestCases, []},
+        {Credo.Check.Refactor.PerceivedComplexity, []},
+        {Credo.Check.Refactor.PipeChainStart, []},
+        {Credo.Check.Refactor.RejectFilter, []},
+        {Credo.Check.Refactor.RejectReject, []},
+        {Credo.Check.Refactor.VariableRebinding, []},
+        {Credo.Check.Warning.ForbiddenModule, []},
+        {Credo.Check.Warning.LeakyEnvironment, []},
+        {Credo.Check.Warning.MapGetUnsafePass, []},
+        {Credo.Check.Warning.MixEnv, []},
+        {Credo.Check.Warning.UnsafeToAtom, []}
+      ]
+    }
+  ]
+}

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,7 @@
 [
   inputs: [
-    "{mix,.formatter}.exs",
-    "config/config.exs",
-    "{lib,test}/**/*.{ex,exs}"
+    ".**.{ex,exs}",
+    "lib/**/*.{ex,exs}",
+    "test/**/*.{ex,exs}"
   ]
 ]

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -10,10 +10,7 @@ defmodule Nuntiux.Mocker do
            opts: Nuntiux.opts()
          }
 
-  @doc """
-  Boots up a mocking process.
-  If the process to be mocked doesn't exist, returns <pre>ignore</pre>.
-  """
+  @doc false
   @spec start_link(process_name, opts) :: ok | ignore
         when process_name: Nuntiux.process_name(),
              opts: Nuntiux.opts(),

--- a/lib/nuntiux/supervisor.ex
+++ b/lib/nuntiux/supervisor.ex
@@ -2,6 +2,8 @@ defmodule Nuntiux.Supervisor do
   @moduledoc false
   use DynamicSupervisor
 
+  require Nuntiux
+
   @supervisor __MODULE__
 
   @impl DynamicSupervisor
@@ -47,18 +49,16 @@ defmodule Nuntiux.Supervisor do
              ok: :ok,
              error: {:error, :not_mocked}
   def stop_mock(process_name) do
-    if process_name in mocked() do
+    Nuntiux.if_mocked(process_name, fn process_name ->
       mocker_pid = Process.whereis(process_name)
       Nuntiux.Mocker.delete(process_name)
       DynamicSupervisor.terminate_child(@supervisor, mocker_pid)
-    else
-      {:error, :not_mocked}
-    end
+    end)
   end
 
   @spec mocked() :: process_names
         when process_names: [Nuntiux.process_name()]
-  defp mocked do
+  def mocked do
     type = :worker
     item = :registered_name
     item_list = [item]

--- a/test/nuntiux_test.exs
+++ b/test/nuntiux_test.exs
@@ -1,5 +1,5 @@
 defmodule NuntiuxTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Nuntiux
 
   @mocked :mocked
@@ -52,7 +52,7 @@ defmodule NuntiuxTest do
     end
   end
 
-  def mocked do
+  defp mocked do
     # A basic plus oner
     receive do
       {caller, ref, a_number} ->


### PR DESCRIPTION
Translated<sup>(1)</sup> from https://github.com/2Latinos/nuntius/pull/28...

## Notes on this implementation

* 🟧 Credo has **A LOT** of non-default stuff
  * even though we may end up with a shorter rule list we wanna go full strict, at this moment, to test its/our limits
* 🟩 macros **ftw** 🎉
  * even if small, in this context, so easily replaced by a function, I wanted to test this out, so went with it (don't hate me yet!)
* 🟩 `defdelegate` for expressiveness/semantics
  * I'd used it in the past, in the context of behaviour implementations, and here it just feels like syntactic sugar (I'm not sure it's much more than that, though)
* 🟧 `.` after function names
  * odd, when coming from the Erlang world, but easy to adapt to
* 🟧 using `&` to pass a function reference
  * odd, when coming from the Erlang world, I think I'd preferred `fn` for consistency, but I get where the language's coming from
* 🟩 `if` used
  * not common, for me, in Erlang, but easy to use in Elixir, since the syntax is much cleaner (if/else, instead of if/true)
* 🟩 string interpolation
  * I think something's [being cooked up for Erlang](https://github.com/erlang/eep/pull/45#issuecomment-1573644525), but `"#{__MODULE__}.mocked_process"` is a ftw
* 🟩 `@doc false`
  * using this instead of `@hidden` or `@private` (since `@doc` is already what you use for regular doc.) is cleaner and makes a lot of sense
* 🟧 jumping to Erlang via `:`
  * it probably wouldn't make sense to replicate all the Erlang public API in Elixir, but e.g. `proc_lib` and `timer` surely could do with some wrappers (this is just aesthetics for me, really 😄)
* 🟧 `defp`/`def`
  * I quite like that Erlang modules' API is exposed at the top (and you don't have to mess with indentation when making something private/public), but there's (dis)advantages to both approaches
  * I miss `rebar3 xref` 😢 
* 🟩 tests' `on_exit(`
  * this is so much more ergonomic than `init_per_testcase`/`end_per_testcase`, so it's a win
* 🟧 variable rebinding (`^`)
  * I don't love this (yet?): coming from an Erlang world and being used to "pinned by default": I shot myself in the foot twice while writing the tests (look at where ^ is used and you can see how easy it is to forget it and have the tests pass)
  * I wished https://www.erlang.org/eeps/eep-0055 would've gotten traction, implemented as a trial, and potentially faded out if the community at large disliked it...
* 🟧 compile-time validations
  * there's some compile-time validations (like checking if a function exists) which are odd when coming from the Erlang world. While the "real world" problem is to potentially not load functions after they're used (and I guess that's what `rebar3 xref` is also used for) I am torn between having better compile-time validation and forcing me to use a compiler option to not have it (choices, choices, ...)

---

<sup>(1)</sup> an Erlang > Elixir translation, as presented here, is not a copy-paste exercise but rather a re-thinking of the implementation in a different language using that language's constructs as best as possible. The goal is to 1. make the API similar, 2. make it work, 3. make it idiomatic.