### PR TITLE
Translate "Add history/1, and reset_history/1"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.elixir_ls/
 _build/
 cover/
 deps/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.14.5
-erlang 26.0.1
+erlang 25.3.2.2

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -93,7 +93,7 @@ defmodule Nuntiux do
   """
   @spec mocked_process(process_name) :: ok | error
         when process_name: process_name(),
-             ok: {:ok, pid()},
+             ok: pid(),
              error: {:error, :not_mocked}
   def mocked_process(process_name) do
     if_mocked(process_name, &Nuntiux.Mocker.mocked_process/1)

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -6,6 +6,7 @@ defmodule Nuntiux do
   @application :nuntiux
 
   @opaque opts :: [{:passthrough?, boolean()} | {:history?, boolean()}]
+  @opaque event :: %{timestamp: integer(), message: term()}
 
   @type process_name :: atom()
 
@@ -73,6 +74,16 @@ defmodule Nuntiux do
   end
 
   @doc """
+  Signals if option `history?` is enabled or not.
+  """
+  @spec history?(opts) :: history?
+        when opts: opts(),
+             history?: boolean()
+  def history?(opts) do
+    opts[:history?]
+  end
+
+  @doc """
   Removes a mocking process.
   """
   @spec delete(process_name) :: ok | error
@@ -97,5 +108,37 @@ defmodule Nuntiux do
              error: {:error, :not_mocked}
   def mocked_process(process_name) do
     if_mocked(process_name, &Nuntiux.Mocker.mocked_process/1)
+  end
+
+  @doc """
+  Returns the history of messages received by a mocked process.
+  """
+  @spec history(process_name) :: ok | error
+        when process_name: process_name(),
+             ok: [event()],
+             error: {:error, :not_mocked}
+  def history(process_name) do
+    if_mocked(process_name, &Nuntiux.Mocker.history/1)
+  end
+
+  @doc """
+  Erases the history for a mocked process.
+  """
+  @spec reset_history(process_name) :: ok | error
+        when process_name: process_name(),
+             ok: :ok,
+             error: {:error, :not_mocked}
+  def reset_history(process_name) do
+    if_mocked(process_name, &Nuntiux.Mocker.reset_history/1)
+  end
+
+  @doc """
+  """
+  @spec new_event(timestamp, message) :: event
+        when timestamp: integer(),
+             message: term(),
+             event: event
+  def new_event(timestamp, message) do
+    %{timestamp: timestamp, message: message}
   end
 end

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -5,9 +5,8 @@ defmodule Nuntiux do
 
   @application :nuntiux
 
-  @opaque opts :: [{:passthrough?, boolean()} | {:history?, boolean()}]
-  @opaque event :: %{timestamp: integer(), message: term()}
-
+  @type opts :: [{:passthrough?, boolean()} | {:history?, boolean()}]
+  @type event :: %{timestamp: integer(), message: term()}
   @type process_name :: atom()
 
   defmacro if_mocked(process_name, fun) do

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -130,14 +130,4 @@ defmodule Nuntiux do
   def reset_history(process_name) do
     if_mocked(process_name, &Nuntiux.Mocker.reset_history/1)
   end
-
-  @doc """
-  """
-  @spec new_event(timestamp, message) :: event
-        when timestamp: integer(),
-             message: term(),
-             event: event
-  def new_event(timestamp, message) do
-    %{timestamp: timestamp, message: message}
-  end
 end

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -63,7 +63,7 @@ defmodule Nuntiux do
   end
 
   @doc """
-  Signals if option `passthrough` is enabled or not.
+  Signals if option `passthrough?` is enabled or not.
   """
   @spec passthrough?(opts) :: passthrough?
         when opts: opts(),

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -71,6 +71,7 @@ defmodule Nuntiux.Mocker do
              ok: :ok
   def reset_history(process_name) do
     send(process_name, {:"$nuntiux.cast", :reset_history})
+    :ok
   end
 
   @doc false

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -7,6 +7,7 @@ defmodule Nuntiux.Mocker do
            process_name: Nuntiux.process_name(),
            process_pid: pid(),
            process_monitor: reference(),
+           history: [Nuntiux.event()],
            opts: Nuntiux.opts()
          }
 
@@ -54,6 +55,25 @@ defmodule Nuntiux.Mocker do
   end
 
   @doc false
+  @spec history(process_name) :: ok
+        when process_name: Nuntiux.process_name(),
+             ok: [Nuntiux.event()]
+  def history(process_name) do
+    label = :"$nuntiux.call"
+    request = :history
+    {:ok, history} = :gen.call(process_name, label, request)
+    history
+  end
+
+  @doc false
+  @spec reset_history(process_name) :: ok
+        when process_name: Nuntiux.process_name(),
+             ok: :ok
+  def reset_history(process_name) do
+    send(process_name, {:"$nuntiux.cast", :reset_history})
+  end
+
+  @doc false
   @spec init(process_name, process_pid, opts) :: no_return
         when process_name: Nuntiux.process_name(),
              process_pid: pid(),
@@ -69,6 +89,7 @@ defmodule Nuntiux.Mocker do
       process_name: process_name,
       process_pid: process_pid,
       process_monitor: process_monitor,
+      history: [],
       opts: opts
     })
   end
@@ -79,32 +100,33 @@ defmodule Nuntiux.Mocker do
   defp loop(state) do
     process_monitor = state.process_monitor
     process_pid = state.process_pid
-    passthrough? = Nuntiux.passthrough?(state.opts)
+    history = state.history
 
-    receive do
-      {:DOWN, ^process_monitor, :process, ^process_pid, reason} ->
-        exit(reason)
+    next_state =
+      receive do
+        {:DOWN, ^process_monitor, :process, ^process_pid, reason} ->
+          exit(reason)
 
-      message ->
-        maybe_passthrough(passthrough?, process_pid, message)
-    end
+        {:"$nuntiux.call", from, :history} ->
+          :gen.reply(from, Enum.reverse(history))
+          state
 
-    loop(state)
+        {:"$nuntiux.cast", :reset_history} ->
+          %{state | history: []}
+
+        message ->
+          handle_message(message, state)
+      end
+
+    loop(next_state)
   end
 
-  @spec maybe_passthrough(passthrough?, process_pid, message) :: message | ignore
-        when passthrough?: boolean(),
-             process_pid: pid(),
-             message: any(),
-             ignore: :ignore
-  defp maybe_passthrough(false = _passthrough?, _process_pid, _message) do
-    # We don't pass messages through, we just ignore them.
-    :ignore
-  end
-
-  defp maybe_passthrough(true = _passthrough?, process_pid, message) do
-    # We pass messages through.
-    send(process_pid, message)
+  @spec handle_message(message, state) :: state
+        when message: term(),
+             state: state()
+  defp handle_message(message, state) do
+    maybe_passthrough(message, state)
+    maybe_add_event(message, state)
   end
 
   @spec reregister(process_name, target_pid, source_pid) :: ok
@@ -117,5 +139,40 @@ defmodule Nuntiux.Mocker do
     Process.register(target_pid, process_name)
     if is_pid(source_pid), do: Process.put(@mocked_process_key, source_pid)
     :ok
+  end
+
+  @spec maybe_passthrough(message, state) :: message | ignore
+        when message: term(),
+             state: state(),
+             ignore: :ignore
+  defp maybe_passthrough(message, state) do
+    opts = state.opts
+    process_pid = state.process_pid
+
+    if Nuntiux.passthrough?(opts),
+      do: send(process_pid, message),
+      else: :ignore
+
+    # We don't pass messages through, we just ignore them.
+    :ignore
+  end
+
+  @spec maybe_add_event(message, state) :: state
+        when message: term(),
+             state: state()
+  defp maybe_add_event(message, state) do
+    opts = state.opts
+
+    if Nuntiux.history?(opts) do
+      {_current_value, state} =
+        Map.get_and_update(state, :history, fn history ->
+          timestamp = System.system_time()
+          {history, [%{timestamp: timestamp, message: message} | history]}
+        end)
+
+      state
+    else
+      state
+    end
   end
 end

--- a/test/nuntiux_test.exs
+++ b/test/nuntiux_test.exs
@@ -3,7 +3,7 @@ defmodule NuntiuxTest do
   doctest Nuntiux
 
   setup do
-    Nuntiux.start()
+    {:ok, _modules} = Nuntiux.start()
 
     plus_oner_pid = spawn(&plus_oner/0)
     plus_oner_name = :plus_oner
@@ -38,16 +38,16 @@ defmodule NuntiuxTest do
     test "starts and stops" do
       application = Nuntiux.application()
 
-      Nuntiux.stop()
+      :ok = Nuntiux.stop()
 
       {:ok, apps} = Nuntiux.start()
       [^application | _other] = apps
       no_modules = []
       {:ok, ^no_modules} = Nuntiux.start()
-      Nuntiux.stop()
+      :ok = Nuntiux.stop()
 
       {:ok, [^application]} = Nuntiux.start()
-      Nuntiux.stop()
+      :ok = Nuntiux.stop()
     end
 
     test "has a practically invisible default mock", %{plus_oner_name: plus_oner_name} do
@@ -55,7 +55,7 @@ defmodule NuntiuxTest do
       2 = send2(plus_oner_name, 1)
 
       # We mock the process but we don't handle any message
-      Nuntiux.new(plus_oner_name)
+      :ok = Nuntiux.new(plus_oner_name)
 
       # So, nothing changes
       2 = send2(plus_oner_name, 1)
@@ -75,9 +75,9 @@ defmodule NuntiuxTest do
 
       # Mocking it and later deleting the mock
       # restores the registered name to the mocked process
-      Nuntiux.new(plus_oner_name)
+      :ok = Nuntiux.new(plus_oner_name)
       refute Process.whereis(plus_oner_name) == plus_oner_pid
-      Nuntiux.delete(plus_oner_name)
+      :ok = Nuntiux.delete(plus_oner_name)
       ^plus_oner_pid = Process.whereis(plus_oner_name)
 
       # And the process is, again, not mocked
@@ -96,7 +96,7 @@ defmodule NuntiuxTest do
       {:error, :not_mocked} = Nuntiux.mocked_process(plus_oner_name)
 
       # Once you mock it, you can get the original PID
-      Nuntiux.new(plus_oner_name)
+      :ok = Nuntiux.new(plus_oner_name)
       refute Process.whereis(plus_oner_name) == plus_oner_pid
 
       # And the process appears in the list of mocked processes
@@ -104,11 +104,11 @@ defmodule NuntiuxTest do
       [^plus_oner_name] = Nuntiux.mocked()
 
       # If you mock two processes, they both appear in the list
-      Nuntiux.new(echoer_name)
+      :ok = Nuntiux.new(echoer_name)
       [^echoer_name, ^plus_oner_name] = Enum.sort(Nuntiux.mocked())
 
       # If you remove a mock, it goes away from the list
-      Nuntiux.delete(plus_oner_name)
+      :ok = Nuntiux.delete(plus_oner_name)
       [^echoer_name] = Nuntiux.mocked()
     end
   end


### PR DESCRIPTION
# Description

Translated<sup>(1)</sup> from https://github.com/2Latinos/nuntius/pull/29...

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/2Latinos/nuntiux/blob/main/CONTRIBUTING.md)

## Notes

* 🟨 types as `@type` and `@typep`
  * I quite like that the separation of types into private/public is done merely by the directive they use: this way there's no disconnect between definition and export; I can also see advantages in having it in a separate list, much like I prefer that for functions, where the API is "mirrored" at the top of a module
* 🟨 `:gen` doesn't seem to have an Elixir counterpart either
* 🟩 remnants of Erlang (?)
  * I like to find `->` in certain parts of the language: I wonder what thought process led to this choice (?)
* 🟨 `send/2` spec'ed as `any`
  * if `send` in Elixir is to be Erlang's counterpart for `!`, I think a better spec. would be `@spec send(Process.dest(), message) :: message when message: var` (at the moment, `message` is `any()`, which doesn't convey the same semantics for me)

---

<sup>(1)</sup> an Erlang > Elixir translation, as presented here, is not a copy-paste exercise but rather a re-thinking of the implementation in a different language using that language's constructs as best as possible. The goal is to 1. make the API similar, 2. make it work, 3. make it idiomatic.