### PR TITLE
Translate "Add received/2"

### DIFF
--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -5,9 +5,9 @@ defmodule Nuntiux do
 
   @application :nuntiux
 
-  @type opts :: [{:passthrough?, boolean()} | {:history?, boolean()}]
   @type process_name :: atom()
 
+  @type opts :: Nuntiux.Mocker.opts()
   @type history :: Nuntiux.Mocker.history()
   @type received? :: Nuntiux.Mocker.received?()
   @type event :: Nuntiux.Mocker.event()
@@ -23,9 +23,7 @@ defmodule Nuntiux do
     end
   end
 
-  @doc """
-  Returns the application identifier.
-  """
+  @doc false
   @spec application() :: application
         when application: unquote(@application)
   def application do
@@ -63,26 +61,6 @@ defmodule Nuntiux do
     default_opts = [{:passthrough?, true}, {:history?, true}]
     opts = Keyword.merge(default_opts, opts)
     Nuntiux.Supervisor.start_mock(process_name, opts)
-  end
-
-  @doc """
-  Signals if option `passthrough?` is enabled or not.
-  """
-  @spec passthrough?(opts) :: passthrough?
-        when opts: opts(),
-             passthrough?: boolean()
-  def passthrough?(opts) do
-    opts[:passthrough?]
-  end
-
-  @doc """
-  Signals if option `history?` is enabled or not.
-  """
-  @spec history?(opts) :: history?
-        when opts: opts(),
-             history?: boolean()
-  def history?(opts) do
-    opts[:history?]
   end
 
   @doc """

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -6,8 +6,11 @@ defmodule Nuntiux do
   @application :nuntiux
 
   @type opts :: [{:passthrough?, boolean()} | {:history?, boolean()}]
-  @type event :: %{timestamp: integer(), message: term()}
   @type process_name :: atom()
+
+  @type history :: Nuntiux.Mocker.history()
+  @type received? :: Nuntiux.Mocker.received?()
+  @type event :: Nuntiux.Mocker.event()
 
   defmacro if_mocked(process_name, fun) do
     quote bind_quoted: [

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -114,10 +114,23 @@ defmodule Nuntiux do
   """
   @spec history(process_name) :: ok | error
         when process_name: process_name(),
-             ok: [event()],
+             ok: Nuntiux.Mocker.history(),
              error: {:error, :not_mocked}
   def history(process_name) do
     if_mocked(process_name, &Nuntiux.Mocker.history/1)
+  end
+
+  @doc """
+  Returns whether a particular message was received already.
+  **Note**: it only works with `history?: true`.
+  """
+  @spec received?(process_name, message) :: ok | error
+        when process_name: process_name(),
+             message: term(),
+             ok: Nuntiux.Mocker.received?(),
+             error: {:error, :not_mocked}
+  def received?(process_name, message) do
+    if_mocked(process_name, fn process_name -> Nuntiux.Mocker.received?(process_name, message) end)
   end
 
   @doc """

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -130,7 +130,7 @@ defmodule Nuntiux do
              ok: Nuntiux.Mocker.received?(),
              error: {:error, :not_mocked}
   def received?(process_name, message) do
-    if_mocked(process_name, fn process_name -> Nuntiux.Mocker.received?(process_name, message) end)
+    if_mocked(process_name, &Nuntiux.Mocker.received?(&1, message))
   end
 
   @doc """

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -151,13 +151,8 @@ defmodule Nuntiux.Mocker do
     history = state.history
 
     case request do
-      :history ->
-        Enum.reverse(history)
-
-      {:received?, message0} ->
-        Enum.any?(history, fn %{message: message} ->
-          message == message0
-        end)
+      :history -> Enum.reverse(history)
+      {:received?, message} -> Enum.any?(history, &(&1.message == message))
     end
   end
 

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -3,8 +3,10 @@ defmodule Nuntiux.Mocker do
   A process that mocks another one.
   """
 
-  @type history :: [Nuntiux.event()]
+  @type history :: [event()]
   @type received? :: boolean()
+  @type event :: %{timestamp: integer(), message: term()}
+
   @typep state :: %{
            process_name: Nuntiux.process_name(),
            process_pid: pid(),


### PR DESCRIPTION
# Description

Translated<sup>(1)</sup> from https://github.com/2Latinos/nuntius/pull/30...

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/2Latinos/nuntiux/blob/main/CONTRIBUTING.md)

## Implementation notes

* 🟩 I rather like the seemingly idiomatic `?` and `!` (not used here) elements in function names (`?` also in variable names) to express either "predicate" or "throwable version of..."
  * In Erlang this is only possible if your atoms are surrounded by `'`, which makes for "weird" function names and/or atoms
* 🟩 hurrah for Credo's `Credo.Check.Refactor.VariableRebinding`: it helped me find "issues" in tests, where they would've otherwise passed when they shouldn't.
* 🟨 I used `&(...&1...)` though it can sometimes be hard to understand when the expressions aren't "simple"

---

<sup>(1)</sup> an Erlang > Elixir translation, as presented here, is not a copy-paste exercise but rather a re-thinking of the implementation in a different language using that language's constructs as best as possible. The goal is to 1. make the API similar, 2. make it work, 3. make it idiomatic.