### PR TITLE
Translate "Add expect/2, expect/3, delete/2, and expects/1"

### DIFF
--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -11,6 +11,10 @@ defmodule Nuntiux do
   @type history :: Nuntiux.Mocker.history()
   @type received? :: Nuntiux.Mocker.received?()
   @type event :: Nuntiux.Mocker.event()
+  @type expect_fun :: Nuntiux.Mocker.expect_fun()
+  @type expect_name :: Nuntiux.Mocker.expect_name()
+  @type expect_id :: Nuntiux.Mocker.expect_id()
+  @type expects :: Nuntiux.Mocker.expects()
 
   defmacro if_mocked(process_name, fun) do
     quote bind_quoted: [
@@ -58,19 +62,29 @@ defmodule Nuntiux do
              ok: :ok,
              error: {:error, :not_found}
   def new(process_name, opts \\ []) do
-    default_opts = [{:passthrough?, true}, {:history?, true}]
-    opts = Keyword.merge(default_opts, opts)
     Nuntiux.Supervisor.start_mock(process_name, opts)
   end
 
   @doc """
-  Removes a mocking process.
+  Removes a mocking process or expect function.
+  If the expect function was not already there, this function still returns 'ok'.
+  If the process is not mocked, an error is returned.
   """
-  @spec delete(process_name) :: ok | error
+  @spec delete(process_name, expect_id) :: ok | error
         when process_name: process_name(),
+             expect_id: nil | expect_id(),
              ok: :ok,
              error: {:error, :not_mocked}
-  defdelegate delete(process_name), to: Nuntiux.Supervisor, as: :stop_mock
+  def delete(process_name, expect_id \\ nil) do
+    if_mocked(
+      process_name,
+      fn ->
+        if is_nil(expect_id),
+          do: Nuntiux.Supervisor.stop_mock(process_name),
+          else: Nuntiux.Mocker.delete(process_name, expect_id)
+      end
+    )
+  end
 
   @doc """
   Returns the list of mocked processes.
@@ -87,7 +101,12 @@ defmodule Nuntiux do
              ok: pid(),
              error: {:error, :not_mocked}
   def mocked_process(process_name) do
-    if_mocked(process_name, fn -> Nuntiux.Mocker.mocked_process(process_name) end)
+    if_mocked(
+      process_name,
+      fn ->
+        Nuntiux.Mocker.mocked_process(process_name)
+      end
+    )
   end
 
   @doc """
@@ -95,10 +114,15 @@ defmodule Nuntiux do
   """
   @spec history(process_name) :: ok | error
         when process_name: process_name(),
-             ok: Nuntiux.Mocker.history(),
+             ok: history(),
              error: {:error, :not_mocked}
   def history(process_name) do
-    if_mocked(process_name, fn -> Nuntiux.Mocker.history(process_name) end)
+    if_mocked(
+      process_name,
+      fn ->
+        Nuntiux.Mocker.history(process_name)
+      end
+    )
   end
 
   @doc """
@@ -108,10 +132,15 @@ defmodule Nuntiux do
   @spec received?(process_name, message) :: ok | error
         when process_name: process_name(),
              message: term(),
-             ok: Nuntiux.Mocker.received?(),
+             ok: received?(),
              error: {:error, :not_mocked}
   def received?(process_name, message) do
-    if_mocked(process_name, fn -> Nuntiux.Mocker.received?(process_name, message) end)
+    if_mocked(
+      process_name,
+      fn ->
+        Nuntiux.Mocker.received?(process_name, message)
+      end
+    )
   end
 
   @doc """
@@ -122,6 +151,52 @@ defmodule Nuntiux do
              ok: :ok,
              error: {:error, :not_mocked}
   def reset_history(process_name) do
-    if_mocked(process_name, fn -> Nuntiux.Mocker.reset_history(process_name) end)
+    if_mocked(
+      process_name,
+      fn ->
+        Nuntiux.Mocker.reset_history(process_name)
+      end
+    )
+  end
+
+  @doc """
+  Adds a new (*named*?) expect function to a mocked process.
+  When a message is received by the process, this function will be run on it.
+  If the message doesn't match any clause, nothing will be done.
+  If the process is not mocked, an error is returned.
+  If the expect function is named, and there was already an expect function with that name,
+  it's replaced.
+  If the expect function is named, when it is successfully added or replaced, it'll keep the name
+  as its identifier. Otherwise, a reference is returned as an identifier.
+  """
+  @spec expect(process_name, expect_name, expect_fun) :: ok | error
+        when process_name: process_name(),
+             expect_name: nil | expect_name(),
+             expect_fun: expect_fun(),
+             ok: expect_id(),
+             error: {:error, :not_mocked}
+  def expect(process_name, expect_name \\ nil, expect_fun) do
+    if_mocked(
+      process_name,
+      fn ->
+        Nuntiux.Mocker.expect(process_name, expect_name, expect_fun)
+      end
+    )
+  end
+
+  @doc """
+  Returns the list of expect functions for a process.
+  """
+  @spec expects(process_name) :: ok | error
+        when process_name: process_name(),
+             ok: expects(),
+             error: {:error, :not_mocked}
+  def expects(process_name) do
+    if_mocked(
+      process_name,
+      fn ->
+        Nuntiux.Mocker.expects(process_name)
+      end
+    )
   end
 end

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -18,7 +18,7 @@ defmodule Nuntiux do
             fun: fun
           ] do
       if process_name in mocked(),
-        do: fun.(process_name),
+        do: fun.(),
         else: {:error, :not_mocked}
     end
   end
@@ -87,7 +87,7 @@ defmodule Nuntiux do
              ok: pid(),
              error: {:error, :not_mocked}
   def mocked_process(process_name) do
-    if_mocked(process_name, &Nuntiux.Mocker.mocked_process/1)
+    if_mocked(process_name, fn -> Nuntiux.Mocker.mocked_process(process_name) end)
   end
 
   @doc """
@@ -98,7 +98,7 @@ defmodule Nuntiux do
              ok: Nuntiux.Mocker.history(),
              error: {:error, :not_mocked}
   def history(process_name) do
-    if_mocked(process_name, &Nuntiux.Mocker.history/1)
+    if_mocked(process_name, fn -> Nuntiux.Mocker.history(process_name) end)
   end
 
   @doc """
@@ -111,7 +111,7 @@ defmodule Nuntiux do
              ok: Nuntiux.Mocker.received?(),
              error: {:error, :not_mocked}
   def received?(process_name, message) do
-    if_mocked(process_name, &Nuntiux.Mocker.received?(&1, message))
+    if_mocked(process_name, fn -> Nuntiux.Mocker.received?(process_name, message) end)
   end
 
   @doc """
@@ -122,6 +122,6 @@ defmodule Nuntiux do
              ok: :ok,
              error: {:error, :not_mocked}
   def reset_history(process_name) do
-    if_mocked(process_name, &Nuntiux.Mocker.reset_history/1)
+    if_mocked(process_name, fn -> Nuntiux.Mocker.reset_history(process_name) end)
   end
 end

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -7,17 +7,41 @@ defmodule Nuntiux.Mocker do
   @type history :: [event()]
   @type received? :: boolean()
   @type event :: %{timestamp: integer(), message: term()}
+  @type expect_fun :: (... -> term())
+  @type expect_name :: atom()
+  @type expect_id :: reference() | expect_name()
+  @type expects :: %{expect_id() => expect_fun()}
 
   @typep state :: %{
            process_name: Nuntiux.process_name(),
            process_pid: pid(),
            process_monitor: reference(),
-           history: [event()],
-           opts: opts()
+           history: history(),
+           opts: opts(),
+           expects: expects()
          }
-  @typep request :: :history | {:received?, message :: term()}
+  @typep request_call ::
+           :history
+           | {:received?, message :: term()}
+           | :expects
+  @typep result_call ::
+           history()
+           | received?()
+           | expects()
+  @typep request_cast ::
+           :reset_history
+           | {:delete, expect_id()}
+           | {:expect, expect_id(), expect_fun()}
 
   @mocked_process_key :"#{__MODULE__}.mocked_process"
+  @default_history []
+  @default_opts [{:passthrough?, true}, {:history?, true}]
+  @default_expects %{}
+  @default_state %{
+    history: @default_history,
+    opts: @default_opts,
+    expects: @default_expects
+  }
 
   @doc false
   @spec start_link(process_name, opts) :: ok | ignore
@@ -39,12 +63,44 @@ defmodule Nuntiux.Mocker do
   end
 
   @doc false
-  @spec delete(process_name) :: ok
+  @spec expect(process_name, expect_name, expect_fun) :: ok
         when process_name: Nuntiux.process_name(),
+             expect_name: nil | expect_name(),
+             expect_fun: expect_fun(),
+             ok: expect_id()
+  def expect(process_name, expect_name, expect_fun) do
+    expect_id =
+      if is_nil(expect_name),
+        do: make_ref(),
+        else: expect_name
+
+    request = {:expect, expect_id, expect_fun}
+    cast(process_name, request)
+    expect_id
+  end
+
+  @doc false
+  @spec expects(process_name) :: ok
+        when process_name: Nuntiux.process_name(),
+             ok: expects()
+  def expects(process_name) do
+    request = :expects
+    call(process_name, request)
+  end
+
+  @doc false
+  @spec delete(process_name, expect_id) :: ok
+        when process_name: Nuntiux.process_name(),
+             expect_id: nil | expect_id(),
              ok: :ok
-  def delete(process_name) do
-    process_pid = mocked_process(process_name)
-    reregister(process_name, process_pid)
+  def delete(process_name, expect_id \\ nil) do
+    if is_nil(expect_id) do
+      process_pid = mocked_process(process_name)
+      reregister(process_name, process_pid)
+    else
+      request = {:delete, expect_id}
+      cast(process_name, request)
+    end
   end
 
   @doc false
@@ -84,10 +140,8 @@ defmodule Nuntiux.Mocker do
         when process_name: Nuntiux.process_name(),
              ok: :ok
   def reset_history(process_name) do
-    label = :"$nuntiux.cast"
     request = :reset_history
-    send(process_name, {label, request})
-    :ok
+    cast(process_name, request)
   end
 
   @doc false
@@ -102,23 +156,37 @@ defmodule Nuntiux.Mocker do
     reregister(process_name, mocker_pid, process_pid)
     :proc_lib.init_ack({:ok, mocker_pid})
 
-    loop(%{
-      process_name: process_name,
-      process_pid: process_pid,
-      process_monitor: process_monitor,
-      history: [],
-      opts: opts
-    })
+    opts = Keyword.merge(@default_opts, opts)
+
+    state =
+      Map.merge(@default_state, %{
+        process_name: process_name,
+        process_pid: process_pid,
+        process_monitor: process_monitor,
+        opts: opts
+      })
+
+    loop(state)
   end
 
   @spec call(process_name, request) :: ok
         when process_name: Nuntiux.process_name(),
-             request: request(),
-             ok: history() | received?()
+             request: request_call(),
+             ok: result_call()
   defp call(process_name, request) do
     label = :"$nuntiux.call"
     {:ok, result} = :gen.call(process_name, label, request)
     result
+  end
+
+  @spec cast(process_name, request) :: ok
+        when process_name: Nuntiux.process_name(),
+             request: request_cast(),
+             ok: :ok
+  defp cast(process_name, request) do
+    label = :"$nuntiux.cast"
+    send(process_name, {label, request})
+    :ok
   end
 
   @spec loop(state) :: no_return
@@ -134,11 +202,12 @@ defmodule Nuntiux.Mocker do
           exit(reason)
 
         {:"$nuntiux.call", from, request} ->
-          :gen.reply(from, handle_call(request, state))
+          handled_call = handle_call(request, state)
+          :gen.reply(from, handled_call)
           state
 
-        {:"$nuntiux.cast", :reset_history} ->
-          %{state | history: []}
+        {:"$nuntiux.cast", request} ->
+          handle_cast(request, state)
 
         message ->
           handle_message(message, state)
@@ -148,18 +217,33 @@ defmodule Nuntiux.Mocker do
   end
 
   @spec handle_call(request, state) :: ok
-        when request: request(),
-             ok: history() | received?()
+        when request: request_call(),
+             ok: result_call()
   defp handle_call(request, state) do
-    history = state.history
-
     case request do
-      :history -> Enum.reverse(history)
-      {:received?, message} -> Enum.any?(history, &(&1.message == message))
+      :history -> Enum.reverse(state.history)
+      {:received?, message} -> Enum.any?(state.history, &(&1.message == message))
+      :expects -> state.expects
     end
   end
 
-  @doc false
+  @spec handle_cast(request, state) :: ok
+        when request: request_cast(),
+             state: state(),
+             ok: state
+  defp handle_cast(request, state) do
+    case request do
+      :reset_history ->
+        %{state | history: []}
+
+      {:delete, expect_id} ->
+        %{state | expects: Map.delete(state.expects, expect_id)}
+
+      {:expect, expect_id, expect_fun} ->
+        %{state | expects: Map.put(state.expects, expect_id, expect_fun)}
+    end
+  end
+
   @spec passthrough?(opts) :: passthrough?
         when opts: opts(),
              passthrough?: boolean()
@@ -167,7 +251,6 @@ defmodule Nuntiux.Mocker do
     opts[:passthrough?]
   end
 
-  @doc false
   @spec history?(opts) :: history?
         when opts: opts(),
              history?: boolean()
@@ -179,7 +262,8 @@ defmodule Nuntiux.Mocker do
         when message: term(),
              state: state()
   defp handle_message(message, state) do
-    maybe_passthrough(message, state)
+    expects_ran = maybe_run_expects(message, state.expects)
+    expects_ran or maybe_passthrough(message, state)
     maybe_add_event(message, state)
   end
 
@@ -193,6 +277,30 @@ defmodule Nuntiux.Mocker do
     Process.register(target_pid, process_name)
     if is_pid(source_pid), do: Process.put(@mocked_process_key, source_pid)
     :ok
+  end
+
+  @spec maybe_run_expects(message, expects) :: ok
+        when message: term(),
+             expects: expects(),
+             ok: boolean()
+  defp maybe_run_expects(message, expects) do
+    Enum.reduce(
+      expects,
+      _expects_ran = false,
+      fn
+        {_expect_id, _expect_fun}, true = _done ->
+          true
+
+        {_expect_id, expect_fun}, false ->
+          try do
+            expect_fun.(message)
+            true
+          catch
+            :error, :function_clause ->
+              false
+          end
+      end
+    )
   end
 
   @spec maybe_passthrough(message, state) :: message | ignore

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -150,7 +150,7 @@ defmodule Nuntiux.Mocker do
   @spec handle_call(request, state) :: ok
         when request: request(),
              ok: history() | received?()
-  def handle_call(request, state) do
+  defp handle_call(request, state) do
     history = state.history
 
     case request do
@@ -159,23 +159,19 @@ defmodule Nuntiux.Mocker do
     end
   end
 
-  @doc """
-  Signals if option `passthrough?` is enabled or not.
-  """
+  @doc false
   @spec passthrough?(opts) :: passthrough?
         when opts: opts(),
              passthrough?: boolean()
-  def passthrough?(opts) do
+  defp passthrough?(opts) do
     opts[:passthrough?]
   end
 
-  @doc """
-  Signals if option `history?` is enabled or not.
-  """
+  @doc false
   @spec history?(opts) :: history?
         when opts: opts(),
              history?: boolean()
-  def history?(opts) do
+  defp history?(opts) do
     opts[:history?]
   end
 

--- a/lib/nuntiux/supervisor.ex
+++ b/lib/nuntiux/supervisor.ex
@@ -49,7 +49,7 @@ defmodule Nuntiux.Supervisor do
              ok: :ok,
              error: {:error, :not_mocked}
   def stop_mock(process_name) do
-    Nuntiux.if_mocked(process_name, fn process_name ->
+    Nuntiux.if_mocked(process_name, fn ->
       mocker_pid = Process.whereis(process_name)
       Nuntiux.Mocker.delete(process_name)
       DynamicSupervisor.terminate_child(@supervisor, mocker_pid)

--- a/lib/nuntiux/supervisor.ex
+++ b/lib/nuntiux/supervisor.ex
@@ -2,8 +2,6 @@ defmodule Nuntiux.Supervisor do
   @moduledoc false
   use DynamicSupervisor
 
-  require Nuntiux
-
   @supervisor __MODULE__
 
   @impl DynamicSupervisor
@@ -44,16 +42,13 @@ defmodule Nuntiux.Supervisor do
     end
   end
 
-  @spec stop_mock(process_name) :: ok | error
+  @spec stop_mock(process_name) :: ok
         when process_name: Nuntiux.process_name(),
-             ok: :ok,
-             error: {:error, :not_mocked}
+             ok: :ok
   def stop_mock(process_name) do
-    Nuntiux.if_mocked(process_name, fn ->
-      mocker_pid = Process.whereis(process_name)
-      Nuntiux.Mocker.delete(process_name)
-      DynamicSupervisor.terminate_child(@supervisor, mocker_pid)
-    end)
+    mocker_pid = Process.whereis(process_name)
+    Nuntiux.Mocker.delete(process_name)
+    :ok = DynamicSupervisor.terminate_child(@supervisor, mocker_pid)
   end
 
   @spec mocked() :: process_names


### PR DESCRIPTION
# Description

Translated<sup>(1)</sup> from https://github.com/2Latinos/nuntius/pull/31...

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/2Latinos/nuntiux/blob/main/CONTRIBUTING.md)

## Implementation notes

* 🟨 `alias`/`import`: I have, up until now, decided to not use `alias` or `import`
  * it's also part of the exercise, to see how readable it becomes trying to use idiomatic module names and source folders (pretty happy with not using it, so far)
* 🟥 `rebar3 xref` missing!
  * "Found" a few more private functions
* 🟩 optional arguments
  * using optional arguments I was able to "remove" `delete/1` and `expect/2` from the API definition (though they're available for consumption)

---

<sup>(1)</sup> an Erlang > Elixir translation, as presented here, is not a copy-paste exercise but rather a re-thinking of the implementation in a different language using that language's constructs as best as possible. The goal is to 1. make the API similar, 2. make it work, 3. make it idiomatic.