### PR TITLE
Translate "Update on expect-matching considerations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ the message,
 * `:passed_through?`: an indication of whether or not the received message was passed through to
 the mocked process.
 
+## Caveats
+
+`Nuntiux` tries to execute your expectations by simply calling their declarations inside a
+`try-catch` expression. Because of this, non-matching expectations will return a `function_clause`,
+that is caught.
+Since it's not possible (at this moment) to distinguish a `function_clause` provoked by `Nuntiux`'
+internal code or your own, we propose you to make sure your functions don't fail with a
+`function_clause`.
+You can also check the message history to understand if a given message was mocked and/or
+passed through.
+
 ## Documentation
 
 Documentation is generated with:

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -88,7 +88,7 @@ defmodule Nuntiux do
              opts: opts(),
              ok: :ok,
              error: {:error, :not_found}
-  def new(process_name, opts \\ []) do
+  def new(process_name, opts \\ %{}) do
     Nuntiux.Supervisor.start_mock(process_name, opts)
   end
 

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -323,7 +323,7 @@ defmodule Nuntiux.Mocker do
              expects: expects(),
              expects_matched: expects_matched()
   defp maybe_run_expects(message, expects) do
-    Enum.reduce(
+    Enum.reduce_while(
       expects,
       @label_nomatch,
       fn
@@ -332,10 +332,10 @@ defmodule Nuntiux.Mocker do
 
         {_expect_id, expect_fun}, @label_nomatch ->
           try do
-            {@label_match, expect_fun.(message)}
+            {:cont, {@label_match, expect_fun.(message)}}
           catch
             :error, :function_clause ->
-              @label_nomatch
+              {:cont, @label_nomatch}
           end
       end
     )


### PR DESCRIPTION
# Description

Translated<sup>(1)</sup> from https://github.com/2Latinos/nuntius/pull/39...

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/2Latinos/nuntiux/blob/main/CONTRIBUTING.md)

⚠️ this is branched from [fix/docs](https://github.com/2Latinos/nuntiux/tree/fix/docs), so it will be rebased once the previous one gets merged. (I'll move away from draft once ready)

This is pre- what we'll get from https://github.com/2Latinos/nuntius/pull/51. Considerations in the translated pull request seem to indicate we were Ok to just have a caveat and get it done with, at a certain moment. Maybe this is a better implementation, as the only thing it forces the consumer on is adding a fallback expectation. On the other hand, it should also be possible for us to add a fallback expectation (with known internals) to our default list (at the moment `[]`) and if that one gets called it's because no other was (in which case we could error out, kill the process, log the error for consumption, ...). @elbrujohalcon, thoughts?

## Implementations notes

* 🟩 function headers with defaults 👍 
* 🟨 defining types based on module attributes 👍 (even though the attributes have to be defined prior to the type, which breaks my expectations)
* 🟨 torn between using keyword list for **options** (which seems to be the _most common choice_ for Elixir libs) or a map (which seems to be more flexible, e.g. when it comes to pattern matching)
* 🟩 not having to use `,` everywhere is refreshing

---

<sup>(1)</sup> an Erlang > Elixir translation, as presented here, is not a copy-paste exercise but rather a re-thinking of the implementation in a different language using that language's constructs as best as possible. The goal is to 1. make the API similar, 2. make it work, 3. make it idiomatic.