### PR TITLE
Some tweaks

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -19,7 +19,8 @@
         {Credo.Check.Readability.SinglePipe, []},
         {Credo.Check.Readability.Specs, []},
         {Credo.Check.Readability.StrictModuleLayout, []},
-        {Credo.Check.Readability.WithCustomTaggedTuple, []},
+        # Throwing an exception because we're using `with` as a variable name
+        # {Credo.Check.Readability.WithCustomTaggedTuple, []},
         {Credo.Check.Refactor.ABCSize, []},
         {Credo.Check.Refactor.AppendSingleItem, []},
         {Credo.Check.Refactor.Apply, []},

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,7 +1,7 @@
 ---
 name: Elixir CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   tool-versions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 ---
 name: Lint
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
 
-See the [Releases](../../releases) page.
+See the [Releases](https://github.com/2Latinos/nuntiux/releases) page.

--- a/README.md
+++ b/README.md
@@ -46,16 +46,19 @@ processes, as well as other elements for debugging:
 passed through to the mocked process,
 * `:history?`: when `true` (default: `true`) all messages received by the mock process are
 classified as per [Understanding the message history](#understanding-the-message-history).
+* `:raise_on_nomatch?`: (default: `true`) check [Expectation handling](#expectation-handling) below.
 
 ## Understanding the message history
 
-History elements are classified with 4 keys:
+History elements are classified with 6 keys:
 
 * `:timestamp`: an integer representing Erlang system time in native time unit,
 * `:message`: the message that was received and/or potentially handled by expectations
 (or passed through),
-* `:mocked?`: an indication of whether or not any of the expecations you declared handled
+* `:mocked?`: an indication of whether or not any of the expectations you declared handled
 the message,
+* `:stack`: the stack trace, in case of an exception,
+* `:with`: the expectation return value,
 * `:passed_through?`: an indication of whether or not the received message was passed through to
 the mocked process.
 
@@ -69,6 +72,20 @@ internal code or your own, we propose you to make sure your functions don't fail
 `function_clause`.
 You can also check the message history to understand if a given message was mocked and/or
 passed through.
+
+## Expectation handling
+
+If, when Nuntiux executes your expectations, none matches the input (which means it's better
+to have a catch-all) it'll raise a `Nuntiux.Exception` and use `Logger` to log the exception
+in the test scope. This can be prevented by setting option `:raise_on_nomatch?` to `false`
+(the default is to raise an exception and log).
+
+On the other hand, if an exception occurs inside one of your expectations, Nuntiux will
+also raise a `Nuntiux.Exception` (and log it), so you can analyze what needs to be fixed. In
+these cases, it's probably also best your expectations are named, to ease debugging.
+
+Finally, if you're using ExUnit, remember to configure it with `capture_log: true`, or
+use the appropriate tag next to the failing tests, for easier debugging.
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Find below updated information on our security policy.
 We take the security of this software seriously.
 
 We don't implement a bug bounty program or bounty rewards, but will work with
-you closed to ensure that your findings gets the appropriate handling.
+you to ensure that your findings get the appropriate handling.
 
 ## Reporting Security Issues
 

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -3,6 +3,7 @@ defmodule Nuntiux do
   This is Nuntiux.
   """
 
+  # The same as found in mix.exs
   @application :nuntiux
 
   @typedoc """

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -285,4 +285,11 @@ defmodule Nuntiux do
       end
     )
   end
+
+  defmodule Exception do
+    @moduledoc """
+    For when Nuntiux explicitly raises, in the `!` functions.
+    """
+    defexception [:message]
+  end
 end

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -94,6 +94,22 @@ defmodule Nuntiux do
   end
 
   @doc """
+  The same as `new/2` but raises a `Nuntiux.Exception` in case of error.
+  """
+  @spec new!(process_name, opts) :: process_name
+        when process_name: process_name(),
+             opts: opts()
+  def new!(process_name, opts \\ %{}) do
+    case new(process_name, opts) do
+      {:error, :not_found} ->
+        raise(Nuntiux.Exception, message: "Process #{process_name} not found.")
+
+      :ok ->
+        process_name
+    end
+  end
+
+  @doc """
   Removes a mocking process or expect function.
   If the expect function was not already there, this function still returns 'ok'.
   """
@@ -234,6 +250,24 @@ defmodule Nuntiux do
         Nuntiux.Mocker.expect(process_name, expect_name, expect_fun)
       end
     )
+  end
+
+  @doc """
+  The same as `expect/3` but raises a `Nuntiux.Exception` in case of error.
+  """
+  @spec expect!(process_name, expect_name, expect_fun) :: process_name
+        when process_name: process_name(),
+             expect_name: nil | expect_name(),
+             expect_fun: expect_fun()
+
+  def expect!(process_name, expect_name \\ nil, expect_fun) do
+    case expect(process_name, expect_name, expect_fun) do
+      {:error, :not_mocked} ->
+        raise(Nuntiux.Exception, message: "Process #{process_name} not mocked.")
+
+      _expect_id ->
+        process_name
+    end
   end
 
   @doc """

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -288,8 +288,8 @@ defmodule Nuntiux do
 
   defmodule Exception do
     @moduledoc """
-    For when Nuntiux explicitly raises, in the `!` functions.
+    For when Nuntiux explicitly raises.
     """
-    defexception [:message]
+    defexception message: nil, stack: nil
   end
 end

--- a/lib/nuntiux/exception.ex
+++ b/lib/nuntiux/exception.ex
@@ -1,0 +1,6 @@
+defmodule Nuntiux.Exception do
+  @moduledoc """
+  For when Nuntiux explicitly raises, in the `!` functions.
+  """
+  defexception [:message]
+end

--- a/lib/nuntiux/exception.ex
+++ b/lib/nuntiux/exception.ex
@@ -1,6 +1,0 @@
-defmodule Nuntiux.Exception do
-  @moduledoc """
-  For when Nuntiux explicitly raises, in the `!` functions.
-  """
-  defexception [:message]
-end

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -3,15 +3,20 @@ defmodule Nuntiux.Mocker do
   A process that mocks another one.
   """
 
+  require Logger
+
   @type opts :: %{
           optional(:passthrough?) => boolean(),
-          optional(:history?) => boolean()
+          optional(:history?) => boolean(),
+          optional(:raise_on_nomatch?) => boolean()
         }
   @type history :: [event()]
   @type event :: %{
           timestamp: integer(),
           message: term(),
           mocked?: boolean(),
+          stack: term(),
+          with: term(),
           passed_through?: boolean()
         }
   @type expect_fun :: (message: term() -> expect_fun_result())
@@ -22,7 +27,8 @@ defmodule Nuntiux.Mocker do
   @default_history []
   @default_opts %{
     passthrough?: true,
-    history?: true
+    history?: true,
+    raise_on_nomatch?: true
   }
   @default_expects %{}
   @default_state %{
@@ -36,7 +42,6 @@ defmodule Nuntiux.Mocker do
   @label_cast :"#{__MODULE__}.cast"
   @label_process_pid :"#{__MODULE__}.process_pid"
   @label_current_message :"#{__MODULE__}.current_message"
-  @label_match :"#{__MODULE__}.match"
   @label_nomatch :"#{__MODULE__}.nomatch"
   @label_passed_through :"#{__MODULE__}.passed_through"
 
@@ -61,7 +66,7 @@ defmodule Nuntiux.Mocker do
            :reset_history
            | {:delete, expect_id()}
            | {:expect, expect_id(), expect_fun()}
-  @typep expects_matched :: unquote(@label_nomatch) | {unquote(@label_match), expect_fun_result()}
+  @typep mocked_stack_with :: %{mocked?: boolean(), stack: nil | [term()], with: term()}
 
   @doc false
   @spec start_link(process_name, opts) :: ok | ignore
@@ -308,9 +313,9 @@ defmodule Nuntiux.Mocker do
   defp handle_message(message, state) do
     current_message(message)
     passed_through?(false)
-    expects_matched = maybe_run_expects(message, state.expects)
-    maybe_passthrough(message, expects_matched, state.opts)
-    maybe_add_event(message, expects_matched, state)
+    mocked_stack_with = maybe_run_expects(message, state.expects, state.opts)
+    maybe_passthrough(message, mocked_stack_with, state.opts)
+    maybe_add_event(message, mocked_stack_with, state)
   end
 
   @doc false
@@ -326,63 +331,111 @@ defmodule Nuntiux.Mocker do
     :ok
   end
 
+  # credo:disable-for-lines:51 Credo.Check.Refactor.ABCSize
   @doc false
-  @spec maybe_run_expects(message, expects) :: expects_matched
+  @spec maybe_run_expects(message, expects, opts) :: mocked_stack_with
         when message: term(),
              expects: expects(),
-             expects_matched: expects_matched()
-  defp maybe_run_expects(message, expects) do
-    Enum.reduce_while(
-      expects,
-      @label_nomatch,
-      fn
-        {_expect_id, _expect_fun}, {@label_match, _matched} = result ->
-          {:halt, result}
+             opts: opts(),
+             mocked_stack_with: mocked_stack_with()
+  defp maybe_run_expects(message, expects, opts) do
+    no_match_fun = fn _msg -> @label_nomatch end
+    expects = Enum.reverse([{:_, no_match_fun} | Map.to_list(expects)])
 
-        {_expect_id, expect_fun}, @label_nomatch ->
-          try do
-            {:cont, {@label_match, expect_fun.(message)}}
-          catch
-            :error, :function_clause ->
-              {:cont, @label_nomatch}
-          end
-      end
-    )
+    mocked_stack_with =
+      Enum.reduce_while(
+        expects,
+        mocked_stack_with(false),
+        fn
+          {expect_id, expect_fun}, %{mocked?: false, stack: stack_trace} ->
+            try do
+              expect_fun.(message)
+            else
+              @label_nomatch ->
+                {:halt, mocked_stack_with(false, stack_trace)}
+
+              match ->
+                {:halt, mocked_stack_with(true, stack_trace, match)}
+            catch
+              class, reason ->
+                stack_elem = %{
+                  expect_id: expect_id,
+                  class: class,
+                  reason: reason,
+                  trace: __STACKTRACE__
+                }
+
+                {:cont, mocked_stack_with(false, stack_elem, nil, stack_trace)}
+            end
+        end
+      )
+
+    case mocked_stack_with do
+      %{mocked?: false, stack: stack_trace, with: nil} when opts.raise_on_nomatch? ->
+        ex_args = [message: "No expectation matched", stack: stack_trace]
+        Logger.error(ex_args)
+        raise(Nuntiux.Exception, ex_args)
+
+      _other ->
+        mocked_stack_with
+    end
   end
 
   @doc false
-  @spec maybe_passthrough(message, expects_matched, opts) :: ok
+  @spec mocked_stack_with(mocked?, stack, with, prior_stack) :: mocked_stack_with
+        when mocked?: boolean(),
+             stack: term(),
+             with: term(),
+             prior_stack: term(),
+             mocked_stack_with: mocked_stack_with()
+  defp mocked_stack_with(mocked?, stack \\ nil, with \\ nil, prior_stack \\ nil) do
+    stack0 =
+      if stack != nil do
+        [stack]
+      end
+
+    stack =
+      if prior_stack != nil do
+        [prior_stack] ++ stack0
+      else
+        stack0
+      end
+
+    %{mocked?: mocked?, stack: stack, with: with}
+  end
+
+  @doc false
+  @spec maybe_passthrough(message, mocked_stack_with, opts) :: ok
         when message: term(),
-             expects_matched: expects_matched(),
+             mocked_stack_with: mocked_stack_with(),
              opts: opts(),
              ok: :ok
-  defp maybe_passthrough(_message, {@label_match, _expect_fun_result}, _opts) do
+  defp maybe_passthrough(_message, %{mocked?: true}, _opts) do
     :ok
   end
 
-  defp maybe_passthrough(_message, _expects_matched, %{passthrough?: false}) do
+  defp maybe_passthrough(_message, _mocked_stack_with, %{passthrough?: false}) do
     :ok
   end
 
-  defp maybe_passthrough(message, _expects_matched, _opts) do
+  defp maybe_passthrough(message, _mocked_stack_with, _opts) do
     passthrough(message)
   end
 
   @doc false
-  @spec maybe_add_event(message, expects_matched, state) :: updated_state
+  @spec maybe_add_event(message, mocked_stack_with, state) :: updated_state
         when message: term(),
-             expects_matched: expects_matched(),
+             mocked_stack_with: mocked_stack_with(),
              state: state(),
              updated_state: state()
-  defp maybe_add_event(_message, _expects_matched, %{opts: %{history?: false}} = state) do
+  defp maybe_add_event(_message, _mocked_stack_with, %{opts: %{history?: false}} = state) do
     state
   end
 
-  defp maybe_add_event(message, expects_matched, state) do
+  defp maybe_add_event(message, mocked_stack_with, state) do
     {_current_value, state} =
       Map.get_and_update(state, :history, fn history ->
         timestamp = System.system_time()
-        mocked? = expects_matched != @label_nomatch
         passed_through? = passed_through?()
 
         {history,
@@ -390,7 +443,9 @@ defmodule Nuntiux.Mocker do
            %{
              timestamp: timestamp,
              message: message,
-             mocked?: mocked?,
+             mocked?: mocked_stack_with.mocked?,
+             stack: mocked_stack_with.stack,
+             with: mocked_stack_with.with,
              passed_through?: passed_through?
            }
            | history

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -19,7 +19,6 @@ defmodule Nuntiux.Mocker do
   @type expect_id :: reference() | expect_name()
   @type expects :: %{expect_id() => expect_fun()}
 
-  @mocked_process_key :"#{__MODULE__}.mocked_process"
   @default_history []
   @default_opts %{
     passthrough?: true,
@@ -31,13 +30,15 @@ defmodule Nuntiux.Mocker do
     opts: @default_opts,
     expects: @default_expects
   }
-  @label_call :"$nuntiux.call"
-  @label_cast :"$nuntiux.cast"
-  @label_process_pid :"$nuntiux.process_pid"
-  @label_current_message :"$nuntiux.current_message"
-  @label_match :"$nuntiux.match"
-  @label_nomatch :"$nuntiux.nomatch"
-  @label_passed_through :"$nuntiux.passed_through"
+
+  @label_mocked_process :"#{__MODULE__}.mocked_process"
+  @label_call :"#{__MODULE__}.call"
+  @label_cast :"#{__MODULE__}.cast"
+  @label_process_pid :"#{__MODULE__}.process_pid"
+  @label_current_message :"#{__MODULE__}.current_message"
+  @label_match :"#{__MODULE__}.match"
+  @label_nomatch :"#{__MODULE__}.nomatch"
+  @label_passed_through :"#{__MODULE__}.passed_through"
 
   @typep received? :: boolean()
   @typep expect_fun_result :: term()
@@ -134,7 +135,7 @@ defmodule Nuntiux.Mocker do
       |> Process.whereis()
       |> Process.info(:dictionary)
 
-    Keyword.get(dict, @mocked_process_key)
+    Keyword.get(dict, @label_mocked_process)
   end
 
   @doc false
@@ -314,7 +315,7 @@ defmodule Nuntiux.Mocker do
   defp reregister(process_name, target_pid, source_pid \\ nil) do
     Process.unregister(process_name)
     Process.register(target_pid, process_name)
-    if is_pid(source_pid), do: Process.put(@mocked_process_key, source_pid)
+    if is_pid(source_pid), do: Process.put(@label_mocked_process, source_pid)
     :ok
   end
 

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -217,6 +217,7 @@ defmodule Nuntiux.Mocker do
     loop(state)
   end
 
+  @doc false
   @spec call(process_name, request) :: result_call
         when process_name: Nuntiux.process_name(),
              request: request_call(),
@@ -226,6 +227,7 @@ defmodule Nuntiux.Mocker do
     result
   end
 
+  @doc false
   @spec cast(process_name, request) :: ok
         when process_name: Nuntiux.process_name(),
              request: request_cast(),
@@ -235,6 +237,7 @@ defmodule Nuntiux.Mocker do
     :ok
   end
 
+  @doc false
   @spec loop(state) :: no_return
         when state: state(),
              no_return: no_return()
@@ -262,6 +265,7 @@ defmodule Nuntiux.Mocker do
     loop(next_state)
   end
 
+  @doc false
   @spec handle_call(request, state) :: result_call
         when request: request_call(),
              state: state(),
@@ -278,6 +282,7 @@ defmodule Nuntiux.Mocker do
     state.expects
   end
 
+  @doc false
   @spec handle_cast(request, state) :: updated_state
         when request: request_cast(),
              state: state(),
@@ -295,6 +300,7 @@ defmodule Nuntiux.Mocker do
     end
   end
 
+  @doc false
   @spec handle_message(message, state) :: updated_state
         when message: term(),
              state: state(),
@@ -307,6 +313,7 @@ defmodule Nuntiux.Mocker do
     maybe_add_event(message, expects_matched, state)
   end
 
+  @doc false
   @spec reregister(process_name, target_pid, source_pid) :: ok
         when process_name: Nuntiux.process_name(),
              target_pid: pid(),
@@ -319,6 +326,7 @@ defmodule Nuntiux.Mocker do
     :ok
   end
 
+  @doc false
   @spec maybe_run_expects(message, expects) :: expects_matched
         when message: term(),
              expects: expects(),
@@ -342,6 +350,7 @@ defmodule Nuntiux.Mocker do
     )
   end
 
+  @doc false
   @spec maybe_passthrough(message, expects_matched, opts) :: ok
         when message: term(),
              expects_matched: expects_matched(),
@@ -359,6 +368,7 @@ defmodule Nuntiux.Mocker do
     passthrough(message)
   end
 
+  @doc false
   @spec maybe_add_event(message, expects_matched, state) :: updated_state
         when message: term(),
              expects_matched: expects_matched(),
@@ -390,6 +400,7 @@ defmodule Nuntiux.Mocker do
     state
   end
 
+  @doc false
   @spec process_pid(process_pid) :: ok
         when process_pid: pid(),
              ok: :ok
@@ -398,12 +409,14 @@ defmodule Nuntiux.Mocker do
     :ok
   end
 
+  @doc false
   @spec process_pid() :: pid
         when pid: pid()
   defp process_pid do
     Process.get(@label_process_pid)
   end
 
+  @doc false
   @spec current_message(message) :: ok
         when message: term(),
              ok: :ok
@@ -412,12 +425,14 @@ defmodule Nuntiux.Mocker do
     :ok
   end
 
+  @doc false
   @spec current_message() :: message
         when message: term()
   defp current_message do
     Process.get(@label_current_message)
   end
 
+  @doc false
   @spec passed_through?(new_passed_through?) :: old_passed_through?
         when new_passed_through?: boolean(),
              old_passed_through?: boolean()
@@ -425,6 +440,7 @@ defmodule Nuntiux.Mocker do
     Process.put(@label_passed_through, passed_through?)
   end
 
+  @doc false
   @spec passed_through?() :: passed_through?
         when passed_through?: boolean()
   defp passed_through? do

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule Nuntiux.MixProject do
       deps: deps(),
       description: "A library to mock registered processes",
       dialyzer: dialyzer(),
+      docs: docs(),
       elixir: @elixir,
       elixirc_options: elixirc_options(),
       name: "Nuntiux",
@@ -61,6 +62,20 @@ defmodule Nuntiux.MixProject do
         :unmatched_returns
       ],
       plt_add_deps: :apps_direct
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        "README.md",
+        "SECURITY.md",
+        "CODE_OF_CONDUCT.md",
+        "CONTRIBUTING.md",
+        "LICENSE.md",
+        "CHANGELOG.md"
+      ],
+      main: "readme"
     ]
   end
 

--- a/test/nuntiux_test.exs
+++ b/test/nuntiux_test.exs
@@ -66,6 +66,12 @@ defmodule NuntiuxTest do
       {:error, :not_found} = Nuntiux.new(:non_existing_process)
     end
 
+    test "new!/1 raises an exception if the process to mock doesn't exist" do
+      assert_raise(Nuntiux.Exception, ~r/^Process .* not found\.$/, fn ->
+        Nuntiux.new!(:non_existing_process)
+      end)
+    end
+
     test "processes can be unmocked", %{
       plus_oner_pid: plus_oner_pid,
       plus_oner_name: plus_oner_name
@@ -189,6 +195,22 @@ defmodule NuntiuxTest do
       [] = Nuntiux.history(plus_oner_name)
       false = Nuntiux.received?(plus_oner_name, 1)
       false = Nuntiux.received?(plus_oner_name, 2)
+    end
+
+    test "allows pipelining for more concise code", %{plus_oner_name: plus_oner_name} do
+      ref =
+        plus_oner_name
+        |> Nuntiux.new!()
+        |> Nuntiux.expect!(fn _in -> :ok end)
+        |> Nuntiux.expect(fn _in -> :ok end)
+
+      true = is_reference(ref)
+    end
+
+    test "expect!/2 raises an exception if the target process is not mocked" do
+      assert_raise(Nuntiux.Exception, ~r/^Process .* not mocked\.$/, fn ->
+        Nuntiux.expect!(:non_existing_process, fn -> :irrelevant end)
+      end)
     end
 
     test "allows defining/consulting expectations", %{plus_oner_name: plus_oner_name} do

--- a/test/nuntiux_test.exs
+++ b/test/nuntiux_test.exs
@@ -62,7 +62,7 @@ defmodule NuntiuxTest do
       2 = send2(plus_oner_name, 1)
     end
 
-    test "raises an error if the process to mock doesn't exist" do
+    test "returns an error if the process to mock doesn't exist" do
       {:error, :not_found} = Nuntiux.new(:non_existing_process)
     end
 


### PR DESCRIPTION
# Description

A few tweaks were remaining, after `nuntius` was completely translated. These are those. After that, I'll look at the "issues" in `nuntius` and perform changes here and there, where applicable.

## Implementation notes

* 🟩 the `!` convention to indicate "this'll raise"
* 🟩 `raise` and `defexception`
* 🟩 string interpolation
* 🟩 regexps in `assert_raise` in tests

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/2Latinos/nuntiux/blob/main/CONTRIBUTING.md)
