### PR TITLE
Improved history: keep returned values and exceptions

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -19,7 +19,8 @@
         {Credo.Check.Readability.SinglePipe, []},
         {Credo.Check.Readability.Specs, []},
         {Credo.Check.Readability.StrictModuleLayout, []},
-        {Credo.Check.Readability.WithCustomTaggedTuple, []},
+        # Throwing an exception because we're using `with` as a variable name
+        # {Credo.Check.Readability.WithCustomTaggedTuple, []},
         {Credo.Check.Refactor.ABCSize, []},
         {Credo.Check.Refactor.AppendSingleItem, []},
         {Credo.Check.Refactor.Apply, []},

--- a/README.md
+++ b/README.md
@@ -46,16 +46,19 @@ processes, as well as other elements for debugging:
 passed through to the mocked process,
 * `:history?`: when `true` (default: `true`) all messages received by the mock process are
 classified as per [Understanding the message history](#understanding-the-message-history).
+* `:raise_on_nomatch?`: (default: `true`) check [Expectation handling](#expectation-handling) below.
 
 ## Understanding the message history
 
-History elements are classified with 4 keys:
+History elements are classified with 6 keys:
 
 * `:timestamp`: an integer representing Erlang system time in native time unit,
 * `:message`: the message that was received and/or potentially handled by expectations
 (or passed through),
-* `:mocked?`: an indication of whether or not any of the expecations you declared handled
+* `:mocked?`: an indication of whether or not any of the expectations you declared handled
 the message,
+* `:stack`: the stack trace, in case of an exception,
+* `:with`: the expectation return value,
 * `:passed_through?`: an indication of whether or not the received message was passed through to
 the mocked process.
 
@@ -69,6 +72,20 @@ internal code or your own, we propose you to make sure your functions don't fail
 `function_clause`.
 You can also check the message history to understand if a given message was mocked and/or
 passed through.
+
+## Expectation handling
+
+If, when Nuntiux executes your expectations, none matches the input (which means it's better
+to have a catch-all) it'll raise a `Nuntiux.Exception` and use `Logger` to log the exception
+in the test scope. This can be prevented by setting option `:raise_on_nomatch?` to `false`
+(the default is to raise an exception and log).
+
+On the other hand, if an exception occurs inside one of your expectations, Nuntiux will
+also raise a `Nuntiux.Exception` (and log it), so you can analyze what needs to be fixed. In
+these cases, it's probably also best your expectations are named, to ease debugging.
+
+Finally, if you're using ExUnit, remember to configure it with `capture_log: true`, or
+use the appropriate tag next to the failing tests, for easier debugging.
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Find below updated information on our security policy.
 We take the security of this software seriously.
 
 We don't implement a bug bounty program or bounty rewards, but will work with
-you closed to ensure that your findings gets the appropriate handling.
+you to ensure that your findings get the appropriate handling.
 
 ## Reporting Security Issues
 

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -288,8 +288,8 @@ defmodule Nuntiux do
 
   defmodule Exception do
     @moduledoc """
-    For when Nuntiux explicitly raises, in the `!` functions.
+    For when Nuntiux explicitly raises.
     """
-    defexception [:message]
+    defexception message: nil, stack: nil
   end
 end

--- a/lib/nuntiux/mocker.ex
+++ b/lib/nuntiux/mocker.ex
@@ -3,15 +3,20 @@ defmodule Nuntiux.Mocker do
   A process that mocks another one.
   """
 
+  require Logger
+
   @type opts :: %{
           optional(:passthrough?) => boolean(),
-          optional(:history?) => boolean()
+          optional(:history?) => boolean(),
+          optional(:raise_on_nomatch?) => boolean()
         }
   @type history :: [event()]
   @type event :: %{
           timestamp: integer(),
           message: term(),
           mocked?: boolean(),
+          stack: term(),
+          with: term(),
           passed_through?: boolean()
         }
   @type expect_fun :: (message: term() -> expect_fun_result())
@@ -22,7 +27,8 @@ defmodule Nuntiux.Mocker do
   @default_history []
   @default_opts %{
     passthrough?: true,
-    history?: true
+    history?: true,
+    raise_on_nomatch?: true
   }
   @default_expects %{}
   @default_state %{
@@ -36,7 +42,6 @@ defmodule Nuntiux.Mocker do
   @label_cast :"#{__MODULE__}.cast"
   @label_process_pid :"#{__MODULE__}.process_pid"
   @label_current_message :"#{__MODULE__}.current_message"
-  @label_match :"#{__MODULE__}.match"
   @label_nomatch :"#{__MODULE__}.nomatch"
   @label_passed_through :"#{__MODULE__}.passed_through"
 
@@ -61,7 +66,7 @@ defmodule Nuntiux.Mocker do
            :reset_history
            | {:delete, expect_id()}
            | {:expect, expect_id(), expect_fun()}
-  @typep expects_matched :: unquote(@label_nomatch) | {unquote(@label_match), expect_fun_result()}
+  @typep mocked_stack_with :: %{mocked?: boolean(), stack: nil | [term()], with: term()}
 
   @doc false
   @spec start_link(process_name, opts) :: ok | ignore
@@ -308,9 +313,9 @@ defmodule Nuntiux.Mocker do
   defp handle_message(message, state) do
     current_message(message)
     passed_through?(false)
-    expects_matched = maybe_run_expects(message, state.expects)
-    maybe_passthrough(message, expects_matched, state.opts)
-    maybe_add_event(message, expects_matched, state)
+    mocked_stack_with = maybe_run_expects(message, state.expects, state.opts)
+    maybe_passthrough(message, mocked_stack_with, state.opts)
+    maybe_add_event(message, mocked_stack_with, state)
   end
 
   @doc false
@@ -326,63 +331,111 @@ defmodule Nuntiux.Mocker do
     :ok
   end
 
+  # credo:disable-for-lines:51 Credo.Check.Refactor.ABCSize
   @doc false
-  @spec maybe_run_expects(message, expects) :: expects_matched
+  @spec maybe_run_expects(message, expects, opts) :: mocked_stack_with
         when message: term(),
              expects: expects(),
-             expects_matched: expects_matched()
-  defp maybe_run_expects(message, expects) do
-    Enum.reduce_while(
-      expects,
-      @label_nomatch,
-      fn
-        {_expect_id, _expect_fun}, {@label_match, _matched} = result ->
-          {:halt, result}
+             opts: opts(),
+             mocked_stack_with: mocked_stack_with()
+  defp maybe_run_expects(message, expects, opts) do
+    no_match_fun = fn _msg -> @label_nomatch end
+    expects = Enum.reverse([{:_, no_match_fun} | Map.to_list(expects)])
 
-        {_expect_id, expect_fun}, @label_nomatch ->
-          try do
-            {:cont, {@label_match, expect_fun.(message)}}
-          catch
-            :error, :function_clause ->
-              {:cont, @label_nomatch}
-          end
-      end
-    )
+    mocked_stack_with =
+      Enum.reduce_while(
+        expects,
+        mocked_stack_with(false),
+        fn
+          {expect_id, expect_fun}, %{mocked?: false, stack: stack_trace} ->
+            try do
+              expect_fun.(message)
+            else
+              @label_nomatch ->
+                {:halt, mocked_stack_with(false, stack_trace)}
+
+              match ->
+                {:halt, mocked_stack_with(true, stack_trace, match)}
+            catch
+              class, reason ->
+                stack_elem = %{
+                  expect_id: expect_id,
+                  class: class,
+                  reason: reason,
+                  trace: __STACKTRACE__
+                }
+
+                {:cont, mocked_stack_with(false, stack_elem, nil, stack_trace)}
+            end
+        end
+      )
+
+    case mocked_stack_with do
+      %{mocked?: false, stack: stack_trace, with: nil} when opts.raise_on_nomatch? ->
+        ex_args = [message: "No expectation matched", stack: stack_trace]
+        Logger.error(ex_args)
+        raise(Nuntiux.Exception, ex_args)
+
+      _other ->
+        mocked_stack_with
+    end
   end
 
   @doc false
-  @spec maybe_passthrough(message, expects_matched, opts) :: ok
+  @spec mocked_stack_with(mocked?, stack, with, prior_stack) :: mocked_stack_with
+        when mocked?: boolean(),
+             stack: term(),
+             with: term(),
+             prior_stack: term(),
+             mocked_stack_with: mocked_stack_with()
+  defp mocked_stack_with(mocked?, stack \\ nil, with \\ nil, prior_stack \\ nil) do
+    stack0 =
+      if stack != nil do
+        [stack]
+      end
+
+    stack =
+      if prior_stack != nil do
+        [prior_stack] ++ stack0
+      else
+        stack0
+      end
+
+    %{mocked?: mocked?, stack: stack, with: with}
+  end
+
+  @doc false
+  @spec maybe_passthrough(message, mocked_stack_with, opts) :: ok
         when message: term(),
-             expects_matched: expects_matched(),
+             mocked_stack_with: mocked_stack_with(),
              opts: opts(),
              ok: :ok
-  defp maybe_passthrough(_message, {@label_match, _expect_fun_result}, _opts) do
+  defp maybe_passthrough(_message, %{mocked?: true}, _opts) do
     :ok
   end
 
-  defp maybe_passthrough(_message, _expects_matched, %{passthrough?: false}) do
+  defp maybe_passthrough(_message, _mocked_stack_with, %{passthrough?: false}) do
     :ok
   end
 
-  defp maybe_passthrough(message, _expects_matched, _opts) do
+  defp maybe_passthrough(message, _mocked_stack_with, _opts) do
     passthrough(message)
   end
 
   @doc false
-  @spec maybe_add_event(message, expects_matched, state) :: updated_state
+  @spec maybe_add_event(message, mocked_stack_with, state) :: updated_state
         when message: term(),
-             expects_matched: expects_matched(),
+             mocked_stack_with: mocked_stack_with(),
              state: state(),
              updated_state: state()
-  defp maybe_add_event(_message, _expects_matched, %{opts: %{history?: false}} = state) do
+  defp maybe_add_event(_message, _mocked_stack_with, %{opts: %{history?: false}} = state) do
     state
   end
 
-  defp maybe_add_event(message, expects_matched, state) do
+  defp maybe_add_event(message, mocked_stack_with, state) do
     {_current_value, state} =
       Map.get_and_update(state, :history, fn history ->
         timestamp = System.system_time()
-        mocked? = expects_matched != @label_nomatch
         passed_through? = passed_through?()
 
         {history,
@@ -390,7 +443,9 @@ defmodule Nuntiux.Mocker do
            %{
              timestamp: timestamp,
              message: message,
-             mocked?: mocked?,
+             mocked?: mocked_stack_with.mocked?,
+             stack: mocked_stack_with.stack,
+             with: mocked_stack_with.with,
              passed_through?: passed_through?
            }
            | history


### PR DESCRIPTION
# Description

Inspiration for this was:

* https://github.com/2Latinos/nuntius/pull/51
* https://github.com/2Latinos/nuntius/pull/58

Targets `feature/some_tweaks` but these days it seems GitHub keeps track of that and moves to a proper target with a target gets merged 💪 

## Implementation notes

* 🟩 `assert` on `capture_log`s

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/2Latinos/nuntiux/blob/main/CONTRIBUTING.md)
