### PR TITLE
Return `{:error, :already_mocked}` when using `new/1,2` over mock

### DIFF
--- a/test/nuntiux_test.exs
+++ b/test/nuntiux_test.exs
@@ -476,6 +476,15 @@ defmodule NuntiuxTest do
       assert captured_log =~ "expect_id: :no_head_matches"
       assert captured_log =~ ":function_clause"
     end
+
+    test "new!/1 raises an exception if trying to mock a mock", %{
+      plus_oner_name: plus_oner_name
+    } do
+      assert_raise(Nuntiux.Exception, ~r/^Process .* is already mocked\.$/, fn ->
+        Nuntiux.new!(plus_oner_name)
+        Nuntiux.new!(plus_oner_name)
+      end)
+    end
   end
 
   defp send2(dest, msg) do


### PR DESCRIPTION
# Description

There are unwanted consequences into mocking a mock. We want to avoid that class of problems.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/2Latinos/nuntiux/blob/main/CONTRIBUTING.md)
