### PR TITLE
Restore pre-`start` state when `stop`'ing Nuntiux

### DIFF
--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -78,6 +78,9 @@ defmodule Nuntiux do
   @spec stop() :: ok
         when ok: :ok
   def stop do
+    for process_name <- mocked(),
+        do: :ok = delete(process_name)
+
     Application.stop(@application)
   end
 

--- a/lib/nuntiux.ex
+++ b/lib/nuntiux.ex
@@ -78,9 +78,7 @@ defmodule Nuntiux do
   @spec stop() :: ok
         when ok: :ok
   def stop do
-    for process_name <- mocked(),
-        do: :ok = delete(process_name)
-
+    Enum.each(mocked(), &delete/1)
     Application.stop(@application)
   end
 

--- a/test/nuntiux_test.exs
+++ b/test/nuntiux_test.exs
@@ -51,6 +51,22 @@ defmodule NuntiuxTest do
       :ok = Nuntiux.stop()
     end
 
+    test "unmocks all processes before stopping", %{
+      plus_oner_name: plus_oner_name,
+      plus_oner_pid: plus_oner_pid,
+      echoer_name: echoer_name,
+      echoer_pid: echoer_pid
+    } do
+      ^plus_oner_name = Nuntiux.new!(plus_oner_name)
+      ^echoer_name = Nuntiux.new!(echoer_name)
+      [:plus_oner, :echoer] = Nuntiux.mocked()
+
+      :ok = Nuntiux.stop()
+      # Compare to original pid, to make sure the registry was restored
+      ^plus_oner_pid = Process.whereis(plus_oner_name)
+      ^echoer_pid = Process.whereis(echoer_name)
+    end
+
     test "has a practically invisible default mock", %{plus_oner_name: plus_oner_name} do
       # Original state
       2 = send2(plus_oner_name, 1)


### PR DESCRIPTION
# Description

We consider the implications of `stop`: we thus restore pre-`start` state when `stop`ing the application.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/2Latinos/nuntiux/blob/main/CONTRIBUTING.md)
